### PR TITLE
tmux: add parentheses around zoomed window

### DIFF
--- a/tmux/falcon.conf
+++ b/tmux/falcon.conf
@@ -23,7 +23,7 @@ setw -g window-status-activity-fg "colour208"
 setw -g window-status-separator ""
 setw -g window-status-bg "#3e3e40"
 setw -g window-status-format "#[fg=#afafb2,bg=#3e3e40] #I:#W "
-setw -g window-status-current-format "#[fg=black,bg=magenta] #I:#W "
+setw -g window-status-current-format "#[fg=black,bg=magenta] #I:#{?window_zoomed_flag,#[fg=black](,}#W#{?window_zoomed_flag,#[fg=black]),} "
 
 set -g status-left-attr "none"
 set -g status-left-length "100"


### PR DESCRIPTION
Requires tmux >= 1.9.

![zoomtmux](https://user-images.githubusercontent.com/6705160/37252532-b14818e4-2522-11e8-9a24-1e57fcdd4d84.gif)
