### PR TITLE
Add alacritty terminal color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Coverage:
     * Yaml
     * Zsh
 * Tmux
-* Kitty
 * iTerm2
+* Kitty
+* alacritty
 * git
 * exa
 
@@ -52,7 +53,7 @@ Vim colour scheme built with [estilo](https://github.com/jacoborus/estilo). Kudo
 
 ### Prerequisites
 
-This colour scheme assumes that you have a working terminal (see iTerm2 and Kitty below) with **bold** and *italic* working. For Vim / Neovim and Tmux a similar assumption is made. How to do this is outside the scope of this README but I wish you well in your endeavours and searching to get it working :) Struggling with these small things (yet irksome!) is part of the fun amirite?!
+This colour scheme assumes that you have a working terminal (see iTerm2, Kitty and alacritty below) with **bold** and *italic* working. For Vim / Neovim and Tmux a similar assumption is made. How to do this is outside the scope of this README but I wish you well in your endeavours and searching to get it working :) Struggling with these small things (yet irksome!) is part of the fun amirite?!
 
 To get going with the colour scheme, either install this repo using a Vim / Neovim plugin manager or clone / download the repo to a folder of your choosing.
 
@@ -99,9 +100,15 @@ To use in iTerm2, go to: `Preferences > Profiles > (Profile Name in left pane) >
 
 To use in kitty, copy and paste the values in the `kitty.conf` into the bottom of your `kitty.conf` file (usually in `~/Library/Preferences/kitty/kitty.conf`).
 
+### alacritty
+
+[alacritty project home page](https://github.com/jwilm/alacritty)
+
+To use in alacritty, put the color configuration from `alacritty.yml` into your `alacritty.yml` file (usually in `~/Library/Preferences/alacritty/alacritty.yml` or `~/.config/alacritty/alacritty.yml`).
+
 ### Tmux
 
-A tmux configuration file is included in the `tmux` directory. It depends on the colours in your terminal being set to the falcon colour scheme (e.g. iTerm2 or Kitty). To include into your tmux setup put something like the following in your `.tmux.conf`:
+A tmux configuration file is included in the `tmux` directory. It depends on the colours in your terminal being set to the falcon colour scheme (e.g. iTerm2, Kitty or alacritty). To include into your tmux setup put something like the following in your `.tmux.conf`:
 
 ```
 source-file /path/to/falcon/tmux/falcon.conf

--- a/alacritty/alacritty.yml
+++ b/alacritty/alacritty.yml
@@ -1,0 +1,38 @@
+# falcon colorscheme for alacritty
+# by fenetikm, https://github.com/fenetikm/falcon
+colors:
+  # Default colors
+  primary:
+    background: '0x0b0b1a'
+    foreground: '0xd4d4d9'
+
+  # Colors the cursor will use if `custom_cursor_colors` is true
+  cursor:
+    text: '0x282828'
+    cursor: '0xffefbf'
+
+  # Normal colors
+  normal:
+    black:   '0x0b0b1a'
+    red:     '0xff794c'
+    green:   '0x85a663'
+    yellow:  '0xffd966'
+    blue:    '0x8fa3bf'
+    magenta: '0xffac59'
+    cyan:    '0x85ccc0'
+    white:   '0xfdfdff'
+
+  # Bright colors
+  bright:
+    black:   '0x000002'
+    red:     '0xff4000'
+    green:   '0x598033'
+    yellow:  '0xffbf00'
+    blue:    '0x306cbf'
+    magenta: '0xff8000'
+    cyan:    '0x30bfa7'
+    white:   '0xd4d4d9'
+
+# Use custom cursor colors. If true, display the cursor in the cursor.foreground
+# and cursor.background colors, otherwise invert the colors of the cursor.
+custom_cursor_colors: true


### PR DESCRIPTION
This PR adds a falcon color scheme configuration for the [alacritty](https://github.com/jwilm/alacritty) terminal emulator.

It both includes the configuration file, and a description in the README on how to install it, consistent to the other applications.