### PR TITLE
Do not override existing g:fzf_colors variable

### DIFF
--- a/plugin/falcon.vim
+++ b/plugin/falcon.vim
@@ -9,20 +9,22 @@ endif
 let g:loaded_falcon=1
 
 " Required as colors will come from terminal without
-let g:fzf_colors=
-  \ { 'fg':      ['fg', 'Comment'],
-    \ 'bg':      ['bg', 'NormalFloatAlt'],
-    \ 'hl':      ['fg', 'Normal'],
-    \ 'fg+':     ['fg', 'CursorLine', 'CursorColumn', 'Normal'],
-    \ 'bg+':     ['bg', 'NormalFloatAlt', 'NormalFloatAlt'],
-    \ 'hl+':     ['fg', 'Keyword'],
-    \ 'info':    ['fg', 'PreProc'],
-    \ 'border':  ['fg', 'Ignore'],
-    \ 'prompt':  ['fg', 'Conditional'],
-    \ 'pointer': ['fg', 'Question'],
-    \ 'marker':  ['fg', 'Directory'],
-    \ 'spinner': ['fg', 'Label'],
-    \ 'header':  ['fg', 'Comment'] }
+if !exists('g:fzf_colors')
+  let g:fzf_colors=
+    \ { 'fg':      ['fg', 'Comment'],
+      \ 'bg':      ['bg', 'NormalFloatAlt'],
+      \ 'hl':      ['fg', 'Normal'],
+      \ 'fg+':     ['fg', 'CursorLine', 'CursorColumn', 'Normal'],
+      \ 'bg+':     ['bg', 'NormalFloatAlt', 'NormalFloatAlt'],
+      \ 'hl+':     ['fg', 'Keyword'],
+      \ 'info':    ['fg', 'PreProc'],
+      \ 'border':  ['fg', 'Ignore'],
+      \ 'prompt':  ['fg', 'Conditional'],
+      \ 'pointer': ['fg', 'Question'],
+      \ 'marker':  ['fg', 'Directory'],
+      \ 'spinner': ['fg', 'Label'],
+      \ 'header':  ['fg', 'Comment'] }
+endif
 
 function s:HandleInactiveBackground()
   " NeoVim has support for changing background colour depending on active or not


### PR DESCRIPTION
Using packer.nvim and fzf's configuration compiled into `packer_compiled.vim` (`:PackerCompile`) I was unable to override `g:fzf_colors` variable. It's because `packer_compiled.vim` is read before `~/.local/share/nvim/site/pack/packer/start/falcon/plugin/falcon.vim` which then was overriding my small change.
What do you think? Is guarding like in this PR an acceptable solution to this problem?