### PR TITLE
Add falcon json theme file for Windows Terminal

### DIFF
--- a/windowsterminal/falcon.json
+++ b/windowsterminal/falcon.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "https://aka.ms/terminal-profiles-schema",
+    "schemes":
+    [
+        {
+            "name": "falcon",
+            "background": "#020221",
+            "foreground": "#b4b4b9",
+            "black": "#000004",
+            "red": "#ff3600",
+            "green": "#718e3f",
+            "yellow": "#ffc552",
+            "blue": "#635196",
+            "purple": "#ff761a",
+            "cyan": "#34b5a4",
+            "white": "#b4b4b9",
+            "cursorColor": "#ffe8c0",
+            "brightBlack": "#020221",
+            "brightRed": "#ff8e78",
+            "brightGreen": "#b1bfb1",
+            "brightYellow": "#ffd392",
+            "brightBlue": "#99a4bc",
+            "brightPurple": "#ffb07b",
+            "brightCyan": "#8bccbf",
+            "brightWhite": "#f8f8ff"
+        }
+    ]
+}


### PR DESCRIPTION
Hi,

just found this theme and thought I'd add support for the [Windows Terminal](https://github.com/microsoft/terminal) - it's the default terminal on Windows 11 and an optional install on Windows 10.

Settings files use JSON, there is a one per-user settings file and it is extensible via "fragments". See [documentation](https://docs.microsoft.com/en-us/windows/terminal/json-fragment-extensions).

This JSON file is such a fragment, so that a user can copy it to their machine as-is and it will be picked up and merged with their main config immediately, so that there is no need for them to edit their main configuration file to "install" this theme.

The installation instructions for this would be:

```powershell
# Adding the theme for the current user
New-Item -Path "${env:LocalAppData}\Microsoft\Windows Terminal\Fragments\falcon" -ItemType Directory
Copy-Item .\windowsterminal\falcon.json -Destination "${env:LocalAppData}\Microsoft\Windows Terminal\Fragments\falcon\"

# Adding the theme for all users of the computer (requires Administrator)
New-Item -Path "${env:ProgramData}\Microsoft\Windows Terminal\Fragments\falcon" -ItemType Directory
Copy-Item .\windowsterminal\falcon.json -Destination "${env:ProgramData}\Microsoft\Windows Terminal\Fragments\falcon\"
```