### PR TITLE
feat: ✨ falcon theme plugin for nb

### DIFF
--- a/nb/nbrc
+++ b/nb/nbrc
@@ -1,0 +1,6 @@
+# requires the falcon.nb-theme plugin
+NB_COLOR_THEME=falcon
+# requires the falcon theme for bat
+#NB_SYNTAX_THEME=falcon
+# requires the falcon theme for ace
+#NB_ACE_THEME=falcon

--- a/nb/plugins/falcon.nb-theme
+++ b/nb/plugins/falcon.nb-theme
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+###############################################################################
+# falcon.nb-theme
+#
+# A yellow and blue-gray theme for `nb`.
+#
+# Install with:
+#   nb plugin install https://github.com/fenetikm/falcon/blob/master/nb/plugins/falcon.nb-theme
+#
+# A plugin for `nb`:
+#   https://github.com/xwmx/nb
+###############################################################################
+
+if [[ "${NB_COLOR_THEME}" == "falcon" ]]
+then
+  export NB_COLOR_PRIMARY=221
+  export NB_COLOR_SECONDARY=109
+fi


### PR DESCRIPTION
Plugin theme for the note-taking tool [nb](https://github.com/xwmx/nb), including a config file containing falcon theme settings for optional tools (bat and ace).

![image](https://github.com/user-attachments/assets/240f2d54-cf06-40fa-9dff-62da2ff374db)
