### PR TITLE
fix: 🐛 typo in a color for sublime

### DIFF
--- a/sublime/falcon.tmTheme
+++ b/sublime/falcon.tmTheme
@@ -35,7 +35,7 @@
 				<key>lineHighlight</key>
 				<string>#073642</string><!-- base02 -->
 				<key>selection</key>
-				<string>#ddcfbfb</string><!-- base02 -->
+				<string>#ddcfbf</string><!-- base02 -->
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Detected this typo while using this file for the theme for Ace.

This file is a base for other tools theme like bat, yazi or ace.